### PR TITLE
Fix SSL connection issues.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,12 @@ Loaded from tls-12.example.com
 Loaded from tls-13.example.com
 ```
 
-Run a testing Bash script with the `openssl s_client`. Note that you need to type enter a few times to exit the command for now.
+Run a testing Bash script with the `openssl s_client`.
 
 ```
+$ grep '^TLS.Min' /etc/crypto-policies/back-ends/opensslcnf.config
+TLS.MinProtocol = TLSv1
+
 $ ./tmp/test_with_openssl_s_client.sh
 + DOMAINS='
     tls-10.example.com
@@ -72,20 +75,18 @@ $ ./tmp/test_with_openssl_s_client.sh
 + mkdir -p log/openssl-s_client
 + for domain in ${DOMAINS}
 + openssl s_client -connect tls-10.example.com:443 -CAfile tmp/test.crt
-+ echo 'Failed from tls-10.example.com'
-Failed from tls-10.example.com
++ echo 'Passed from tls-10.example.com'
+Passed from tls-10.example.com
 + for domain in ${DOMAINS}
 + openssl s_client -connect tls-11.example.com:443 -CAfile tmp/test.crt
-+ echo 'Failed from tls-11.example.com'
-Failed from tls-11.example.com
++ echo 'Passed from tls-11.example.com'
+Passed from tls-11.example.com
 + for domain in ${DOMAINS}
 + openssl s_client -connect tls-12.example.com:443 -CAfile tmp/test.crt
-
 + echo 'Passed from tls-12.example.com'
 Passed from tls-12.example.com
 + for domain in ${DOMAINS}
 + openssl s_client -connect tls-13.example.com:443 -CAfile tmp/test.crt
-
 + echo 'Passed from tls-13.example.com'
 Passed from tls-13.example.com
 ```

--- a/assets/test_with_openssl_s_client.sh.tmpl
+++ b/assets/test_with_openssl_s_client.sh.tmpl
@@ -16,6 +16,7 @@ mkdir -p "${LOG_DIR}"
 
 for domain in ${DOMAINS}; do
     if ! openssl s_client -connect "${domain}:443" -CAfile "${CA_FILE}" \
+        < /dev/null \
         > "${LOG_DIR}/${domain}.stdout.log" \
         2> "${LOG_DIR}/${domain}.stderr.log"; then
         echo "Failed from ${domain}"

--- a/log/openssl-s_client/tls-10.example.com.stderr.log
+++ b/log/openssl-s_client/tls-10.example.com.stderr.log
@@ -1,1 +1,3 @@
-00DEEE19BA7F0000:error:0A00042E:SSL routines:ssl3_read_bytes:tlsv1 alert protocol version:ssl/record/rec_layer_s3.c:1586:SSL alert number 70
+depth=0 CN = *.example.com
+verify return:1
+DONE

--- a/log/openssl-s_client/tls-10.example.com.stdout.log
+++ b/log/openssl-s_client/tls-10.example.com.stdout.log
@@ -1,17 +1,85 @@
 CONNECTED(00000003)
 ---
-no peer certificate available
+Certificate chain
+ 0 s:CN = *.example.com
+   i:CN = *.example.com
+   a:PKEY: rsaEncryption, 4096 (bit); sigalg: RSA-SHA512
+   v:NotBefore: Jun 11 11:57:48 2024 GMT; NotAfter: Jul 11 11:57:48 2024 GMT
+---
+Server certificate
+-----BEGIN CERTIFICATE-----
+MIIEtzCCAp8CFEyaGdxPpoNY4Rz62jUDfOK24yIgMA0GCSqGSIb3DQEBDQUAMBgx
+FjAUBgNVBAMMDSouZXhhbXBsZS5jb20wHhcNMjQwNjExMTE1NzQ4WhcNMjQwNzEx
+MTE1NzQ4WjAYMRYwFAYDVQQDDA0qLmV4YW1wbGUuY29tMIICIjANBgkqhkiG9w0B
+AQEFAAOCAg8AMIICCgKCAgEAwgt4Rb+wZinXrtB3wtv0GAVAXPm9Y+2YkwHdd0qH
+BWLREyuXagXhn5iIvOGhkFe5OaPruKr+VrICzNvR7WYuSOaY6nTwaKJLXko4oH2f
+Aleq0a8L07PcLh5kptCtRRN6dWl/IQwHxjVpDjXGK9KTyvBx1b8Am7jiRb6QU65Q
+L8pokv5uHW9HxysGNCR0B6Sk4hZo473oLQzrOP0ZaPnhGQ6a3FPmPEH1ZnJoGWXg
+1reIruZpOv/VI7VBBWXsRH0/KQQwdObzb+JG0aT5sAT7BIgLjVFVvHZXHbxEQkRr
+72oArwIh5G9HSI4n6AWaPFutPnoYPlGwZ8oDC73Gg5/RhHT5cdbpg6FSgmdjw4aN
+aQ+bnjDUcPJMnWZVhs2oWupH8lEhkoTxOeL2x+PCEWDgjjVfnn9/4k7j1T7zmT7X
+nbIyBblDckt6tVrpQ31xR7XQEDvsYTBkY+kUnESUFky6GnjS9QUdvxWE+srVo0vv
+u8jlwCv0wRhJWVN57xBzYRho2UYB9aWH+cV0TcUp5Ic2mdJbMnRH7mk0VQEPS6Km
+k3IpECe3RgwVMeb/dst2Ppq9ZU8cNTA1LccNZNeDvJ042E5tg9VLtitkskIDqOfx
+bOZIiybV3raab63P4IfD15ExkE21ut3xjh3y5hevCi8FLP1d3e+yxLPQNIQNfYvz
+jSkCAwEAATANBgkqhkiG9w0BAQ0FAAOCAgEAY4ofAE0LS/nldp4iMttP5IQK9N9A
+N2g/TnEywFRkG9Ckrg+SgagK6baTG5AEDgDNnsu+oTbnWp6Sz4gnMX8sBysSzK1G
+RoujiaX6gJFrK6AbJkKXd+fQryfDMC299/oufmDhwx2IhxVqV26940n/aIv4nNTx
+prqiUwgvaX+5lAzwwcjBhbeDxyLW2TUFdU3KTu7G0TOda314gi+hEUroofavlSXE
+wc1ca7nAAnqWBRjUbqTZXuz/JeG+QDo7k9AzEiV5mJosin+SBWrhkC+W2OcJqOSu
+WdJ9mTBc7npXKz3IqtdqnWjDQ97ibzsiOxfUzTBmxi04OY3Uj6/p9x6fmw2/1zks
+zXrgVOWuXbpCnifqZ85NG8a2ILNu2sksRveK6IuA/Xn7y9EIyZE4tYVuZzKh7r8i
+kGRyTU6rQGGpkHyeCEhQn1UCRXUK1p5whD9SzdUB7UVsXuxS2cLZ/a1xsYooQRxn
+R9rXEBZPw4Yq0CBYgu16ctCQl/i3XM7v142ty4zUPRjFnhL5a9QdIV9Grf17Oxb8
+RW3gPm8x1UrbJcljCTdUzCbpgSBKnuZ2QqhTU5DnDPQAgR0dkOmHvBbByzmLTFVl
+lG8noEzbDBthYR/aWiiKW3wvgFXQFwGnctYQywZblE1MgTbxA+MRZF65fZ/4dVHS
+pWKwuwi5bVZ7Og4=
+-----END CERTIFICATE-----
+subject=CN = *.example.com
+issuer=CN = *.example.com
 ---
 No client certificate CA names sent
+Peer signing digest: MD5-SHA1
+Peer signature type: RSA
+Server Temp Key: X25519, 253 bits
 ---
-SSL handshake has read 7 bytes and written 348 bytes
+SSL handshake has read 2174 bytes and written 457 bytes
 Verification: OK
 ---
-New, (NONE), Cipher is (NONE)
-This TLS version forbids renegotiation.
+New, TLSv1.0, Cipher is ECDHE-RSA-AES256-SHA
+Server public key is 4096 bit
+Secure Renegotiation IS supported
 Compression: NONE
 Expansion: NONE
 No ALPN negotiated
-Early data was not sent
-Verify return code: 0 (ok)
+SSL-Session:
+    Protocol  : TLSv1
+    Cipher    : ECDHE-RSA-AES256-SHA
+    Session-ID: 87CF771A65D77F2D74ECF2BA65A5E236ADBBD8E463D886A0E1E24D4C558788DA
+    Session-ID-ctx: 
+    Master-Key: 89BC62C32F07295A544E70648297527E1FF7E84F789BEB070BF88509A07255AEB98328DF73FA6AD5661717085F6C2D0A
+    PSK identity: None
+    PSK identity hint: None
+    SRP username: None
+    TLS session ticket lifetime hint: 300 (seconds)
+    TLS session ticket:
+    0000 - 6c 47 cf ca 9a 70 b9 f8-16 db 1f 77 03 d0 1b 52   lG...p.....w...R
+    0010 - e1 6c bf 11 65 13 d5 44-2d 57 34 b3 7f d8 a0 99   .l..e..D-W4.....
+    0020 - 8b 81 d0 d7 3c 8b ba 27-3a 1b f4 d0 ce 87 25 d0   ....<..':.....%.
+    0030 - 26 ff 32 d0 3d f4 28 ea-c6 b2 8b 98 aa d0 d6 a1   &.2.=.(.........
+    0040 - 04 50 b6 c4 ef 4d 20 1c-a6 5a 03 2e 10 4d 87 80   .P...M ..Z...M..
+    0050 - 01 a6 43 00 3b 29 5a 1f-e8 26 79 22 de 1b fb 84   ..C.;)Z..&y"....
+    0060 - c6 25 1e 55 1f 22 be cc-12 75 6c 97 2f c6 35 fc   .%.U."...ul./.5.
+    0070 - 60 db 7a 61 e7 2f 1b 2a-e0 23 1b e8 18 ac a2 a2   `.za./.*.#......
+    0080 - 2d 77 ce f3 53 12 6b 1b-ca bc 97 49 3a 6b 90 26   -w..S.k....I:k.&
+    0090 - dc 17 4e 23 7e c5 53 05-3a f7 ef 9b bf fc 9d d2   ..N#~.S.:.......
+    00a0 - eb 24 f2 2e c7 66 a3 e9-d0 0e e6 08 53 65 b3 de   .$...f......Se..
+    00b0 - fb f4 c5 bf 2d f1 03 3b-b0 27 e7 1d d0 d2 3c e5   ....-..;.'....<.
+    00c0 - ce f8 fa 1b fc d8 28 e5-e0 bf 41 bc e1 5f c5 07   ......(...A.._..
+    00d0 - d9 3f 58 4d 5d 07 bd 69-5d 2b 84 49 a5 ac 8e 56   .?XM]..i]+.I...V
+
+    Start Time: 1718107076
+    Timeout   : 7200 (sec)
+    Verify return code: 0 (ok)
+    Extended master secret: yes
 ---

--- a/log/openssl-s_client/tls-11.example.com.stderr.log
+++ b/log/openssl-s_client/tls-11.example.com.stderr.log
@@ -1,1 +1,3 @@
-00BEC88F927F0000:error:0A00042E:SSL routines:ssl3_read_bytes:tlsv1 alert protocol version:ssl/record/rec_layer_s3.c:1586:SSL alert number 70
+depth=0 CN = *.example.com
+verify return:1
+DONE

--- a/log/openssl-s_client/tls-11.example.com.stdout.log
+++ b/log/openssl-s_client/tls-11.example.com.stdout.log
@@ -1,17 +1,85 @@
 CONNECTED(00000003)
 ---
-no peer certificate available
+Certificate chain
+ 0 s:CN = *.example.com
+   i:CN = *.example.com
+   a:PKEY: rsaEncryption, 4096 (bit); sigalg: RSA-SHA512
+   v:NotBefore: Jun 11 11:57:48 2024 GMT; NotAfter: Jul 11 11:57:48 2024 GMT
+---
+Server certificate
+-----BEGIN CERTIFICATE-----
+MIIEtzCCAp8CFEyaGdxPpoNY4Rz62jUDfOK24yIgMA0GCSqGSIb3DQEBDQUAMBgx
+FjAUBgNVBAMMDSouZXhhbXBsZS5jb20wHhcNMjQwNjExMTE1NzQ4WhcNMjQwNzEx
+MTE1NzQ4WjAYMRYwFAYDVQQDDA0qLmV4YW1wbGUuY29tMIICIjANBgkqhkiG9w0B
+AQEFAAOCAg8AMIICCgKCAgEAwgt4Rb+wZinXrtB3wtv0GAVAXPm9Y+2YkwHdd0qH
+BWLREyuXagXhn5iIvOGhkFe5OaPruKr+VrICzNvR7WYuSOaY6nTwaKJLXko4oH2f
+Aleq0a8L07PcLh5kptCtRRN6dWl/IQwHxjVpDjXGK9KTyvBx1b8Am7jiRb6QU65Q
+L8pokv5uHW9HxysGNCR0B6Sk4hZo473oLQzrOP0ZaPnhGQ6a3FPmPEH1ZnJoGWXg
+1reIruZpOv/VI7VBBWXsRH0/KQQwdObzb+JG0aT5sAT7BIgLjVFVvHZXHbxEQkRr
+72oArwIh5G9HSI4n6AWaPFutPnoYPlGwZ8oDC73Gg5/RhHT5cdbpg6FSgmdjw4aN
+aQ+bnjDUcPJMnWZVhs2oWupH8lEhkoTxOeL2x+PCEWDgjjVfnn9/4k7j1T7zmT7X
+nbIyBblDckt6tVrpQ31xR7XQEDvsYTBkY+kUnESUFky6GnjS9QUdvxWE+srVo0vv
+u8jlwCv0wRhJWVN57xBzYRho2UYB9aWH+cV0TcUp5Ic2mdJbMnRH7mk0VQEPS6Km
+k3IpECe3RgwVMeb/dst2Ppq9ZU8cNTA1LccNZNeDvJ042E5tg9VLtitkskIDqOfx
+bOZIiybV3raab63P4IfD15ExkE21ut3xjh3y5hevCi8FLP1d3e+yxLPQNIQNfYvz
+jSkCAwEAATANBgkqhkiG9w0BAQ0FAAOCAgEAY4ofAE0LS/nldp4iMttP5IQK9N9A
+N2g/TnEywFRkG9Ckrg+SgagK6baTG5AEDgDNnsu+oTbnWp6Sz4gnMX8sBysSzK1G
+RoujiaX6gJFrK6AbJkKXd+fQryfDMC299/oufmDhwx2IhxVqV26940n/aIv4nNTx
+prqiUwgvaX+5lAzwwcjBhbeDxyLW2TUFdU3KTu7G0TOda314gi+hEUroofavlSXE
+wc1ca7nAAnqWBRjUbqTZXuz/JeG+QDo7k9AzEiV5mJosin+SBWrhkC+W2OcJqOSu
+WdJ9mTBc7npXKz3IqtdqnWjDQ97ibzsiOxfUzTBmxi04OY3Uj6/p9x6fmw2/1zks
+zXrgVOWuXbpCnifqZ85NG8a2ILNu2sksRveK6IuA/Xn7y9EIyZE4tYVuZzKh7r8i
+kGRyTU6rQGGpkHyeCEhQn1UCRXUK1p5whD9SzdUB7UVsXuxS2cLZ/a1xsYooQRxn
+R9rXEBZPw4Yq0CBYgu16ctCQl/i3XM7v142ty4zUPRjFnhL5a9QdIV9Grf17Oxb8
+RW3gPm8x1UrbJcljCTdUzCbpgSBKnuZ2QqhTU5DnDPQAgR0dkOmHvBbByzmLTFVl
+lG8noEzbDBthYR/aWiiKW3wvgFXQFwGnctYQywZblE1MgTbxA+MRZF65fZ/4dVHS
+pWKwuwi5bVZ7Og4=
+-----END CERTIFICATE-----
+subject=CN = *.example.com
+issuer=CN = *.example.com
 ---
 No client certificate CA names sent
+Peer signing digest: MD5-SHA1
+Peer signature type: RSA
+Server Temp Key: X25519, 253 bits
 ---
-SSL handshake has read 7 bytes and written 348 bytes
+SSL handshake has read 2190 bytes and written 473 bytes
 Verification: OK
 ---
-New, (NONE), Cipher is (NONE)
-This TLS version forbids renegotiation.
+New, TLSv1.0, Cipher is ECDHE-RSA-AES256-SHA
+Server public key is 4096 bit
+Secure Renegotiation IS supported
 Compression: NONE
 Expansion: NONE
 No ALPN negotiated
-Early data was not sent
-Verify return code: 0 (ok)
+SSL-Session:
+    Protocol  : TLSv1.1
+    Cipher    : ECDHE-RSA-AES256-SHA
+    Session-ID: B30FF532812132A0119C662BB7EC54BC170D69D80DAB3B5F63059ECB9CF231ED
+    Session-ID-ctx: 
+    Master-Key: 0E365905772004041C3B32641A2DA1EC369E532EA5347ED1C266D3C8F5823D4AD8470DD1EBC073265AC140FA47F721C2
+    PSK identity: None
+    PSK identity hint: None
+    SRP username: None
+    TLS session ticket lifetime hint: 300 (seconds)
+    TLS session ticket:
+    0000 - 6c 47 cf ca 9a 70 b9 f8-16 db 1f 77 03 d0 1b 52   lG...p.....w...R
+    0010 - 73 e6 d0 b7 4b 95 ed 5e-53 4e 2c c2 db 0b 2a c1   s...K..^SN,...*.
+    0020 - 23 cd e9 08 27 d7 0f bd-aa 23 45 5a 18 ca 66 05   #...'....#EZ..f.
+    0030 - c5 ac 71 3b 1f 80 d2 3c-4e 42 72 6d ec 85 66 75   ..q;...<NBrm..fu
+    0040 - aa dd df d4 a0 d1 a4 7a-a0 ae 09 2c 13 00 b6 ee   .......z...,....
+    0050 - 62 b9 f7 a2 0f 5c dd a2-cb ee d7 bd 3f 06 f9 42   b....\......?..B
+    0060 - c4 ab 94 24 60 e2 20 5d-53 5e 01 a4 c4 79 ae 5c   ...$`. ]S^...y.\
+    0070 - 75 7f 55 e2 8d 98 51 a8-4f c1 4e 66 d0 56 f2 c3   u.U...Q.O.Nf.V..
+    0080 - 18 b7 48 c8 cb 4c c4 88-99 fb 1c 25 d6 36 e8 44   ..H..L.....%.6.D
+    0090 - 4d 01 2d cc 8f 4b 29 9c-e0 09 ae 6b e2 94 bb 90   M.-..K)....k....
+    00a0 - 2a fc df a9 b8 e7 f5 12-75 9b 0b db 13 01 3d e7   *.......u.....=.
+    00b0 - 56 46 ea bd 02 22 c1 26-83 95 ff 8e c7 bb f6 d9   VF...".&........
+    00c0 - 3a f5 6a 6c 95 5c 30 9e-5b 90 93 d8 31 e4 29 c3   :.jl.\0.[...1.).
+    00d0 - 91 f0 48 65 90 bf 1f fc-31 c1 ad 7b 56 45 be f0   ..He....1..{VE..
+
+    Start Time: 1718107076
+    Timeout   : 7200 (sec)
+    Verify return code: 0 (ok)
+    Extended master secret: yes
 ---

--- a/log/openssl-s_client/tls-12.example.com.stderr.log
+++ b/log/openssl-s_client/tls-12.example.com.stderr.log
@@ -1,2 +1,3 @@
 depth=0 CN = *.example.com
 verify return:1
+DONE

--- a/log/openssl-s_client/tls-12.example.com.stdout.log
+++ b/log/openssl-s_client/tls-12.example.com.stdout.log
@@ -4,36 +4,36 @@ Certificate chain
  0 s:CN = *.example.com
    i:CN = *.example.com
    a:PKEY: rsaEncryption, 4096 (bit); sigalg: RSA-SHA512
-   v:NotBefore: Jun  7 13:33:18 2024 GMT; NotAfter: Jul  7 13:33:18 2024 GMT
+   v:NotBefore: Jun 11 11:57:48 2024 GMT; NotAfter: Jul 11 11:57:48 2024 GMT
 ---
 Server certificate
 -----BEGIN CERTIFICATE-----
-MIIEtzCCAp8CFHxM+nJCmNcT68fcqsMkNBnNxp6JMA0GCSqGSIb3DQEBDQUAMBgx
-FjAUBgNVBAMMDSouZXhhbXBsZS5jb20wHhcNMjQwNjA3MTMzMzE4WhcNMjQwNzA3
-MTMzMzE4WjAYMRYwFAYDVQQDDA0qLmV4YW1wbGUuY29tMIICIjANBgkqhkiG9w0B
-AQEFAAOCAg8AMIICCgKCAgEA4f/+lEgymd3u+vHQc8EpT7xXzYRAnb0FqnlTAA9d
-vFEo6D1qhMRbOqecVvAPyNkfmOp2R0zGAZLuSl65b2ZlIMFj1P6YmV6JvWJe7MRL
-phoK2ZBsdEIrBwjlKzoWZaKeMO2txU256oGr1YJBvU97O9ScUssboD+tLVE4I37i
-QfoNrDALKTMZ4vRRug98ZxCYBp7eK1s+nizU+474jf+Ppr4fdiXn+AtOQAqOkN9k
-4XrWr+f/Uua3t2k3siRAvG3KaQFJisTPWPvitYZS0lR1lGx0BmLU5cTu+G+GDbdM
-rLPL7jdQeBusWt++mPCu8NgAdktRYXm1K34LLyQgkiv8kpb/Tw4CGZaTkBA/0Q+X
-w/IBET0uiG0VPYIDlgWmMEjAqn3EmaH4sxQoqoDfRfiSAqC4cMkozxvyP1XuqgUv
-etkVNLaHnREuoZ0X/mPsltvMLsU10+QG2EqPqtNhXjQRDMyFNrloj0T3VlNYIEKX
-xveyAggtG7Yk567eMeInweXQdWpP0ZEApAPHAxMY/FgllyrSnHXIIwT+JZspNS4y
-ezeP+tOFP1v1iXRJscYeHWCZcShYhb/SetHKUTN7VgIFFqgqTsleS98shHy3Ui7h
-j4RIZYjt+x3mAXUsSgVeJkdA9GRxhnCnhEb9LTbGsb+st9f8+BWIpBguWGQ1ECvu
-Aj0CAwEAATANBgkqhkiG9w0BAQ0FAAOCAgEAK6Pv8ESMcuxWAfFmZVyrOeCVGzV7
-ZSb3W9fD+7LHduTG/Irh0JLmsgKmauaBV+Io3UOrdQKUfeMrxdqCG0Y7lupVuv6S
-x20K40PmPwi0GeZHt0Im9FvCFvuo7YzaPHKx3clA1KEDcxUNlUK8O2rIplvWv05K
-d/2lyszo8l0kodcDNL8vzUQz2xXHKOfPOz/V5be2cS3KpMjeDfTEdGsZrohZu1Fk
-Mqx75N3vav9C6UwPDNKWxq9Tdfi85BsPYG/CZa1IUwzlA9CsUzs+q/QwqD5aL5DC
-v97cB2Ah5O9XPDVCWx6IeFJ10D/edF7qM1N4O2jw5eDng4xQ8JYINZgV8n0ffzej
-RqB+EPk1PKdcnDSG82oDbZA2ruQ9qEcRRk0JFLp6FT9F+BXPOpi9q0ljdOq4LTwC
-ZYtktwGRySiZavB2aVnS79+wQHry7Wlfzak/rx8hi8Nz3anH8VREPLeYJdkpi/eH
-L4DXkI9Yy7mxNUpf3zeE57u3tzn4QoTXfnv4Llq3fkPmPyEW7ISnf3UFcU1tBY8r
-4FLNboFOitj8TSmCD4kjAn80ryFFwY3jFlKYZ4PkU292jkhewuNRKQczjkv6XdAJ
-RxiER9oic90u6n7Xeu+k5yFOEE7v8bPAMuJZCHtja/bOPxWEl2ft6fy7a8pxzLAN
-qE0ZG816/MUuTww=
+MIIEtzCCAp8CFEyaGdxPpoNY4Rz62jUDfOK24yIgMA0GCSqGSIb3DQEBDQUAMBgx
+FjAUBgNVBAMMDSouZXhhbXBsZS5jb20wHhcNMjQwNjExMTE1NzQ4WhcNMjQwNzEx
+MTE1NzQ4WjAYMRYwFAYDVQQDDA0qLmV4YW1wbGUuY29tMIICIjANBgkqhkiG9w0B
+AQEFAAOCAg8AMIICCgKCAgEAwgt4Rb+wZinXrtB3wtv0GAVAXPm9Y+2YkwHdd0qH
+BWLREyuXagXhn5iIvOGhkFe5OaPruKr+VrICzNvR7WYuSOaY6nTwaKJLXko4oH2f
+Aleq0a8L07PcLh5kptCtRRN6dWl/IQwHxjVpDjXGK9KTyvBx1b8Am7jiRb6QU65Q
+L8pokv5uHW9HxysGNCR0B6Sk4hZo473oLQzrOP0ZaPnhGQ6a3FPmPEH1ZnJoGWXg
+1reIruZpOv/VI7VBBWXsRH0/KQQwdObzb+JG0aT5sAT7BIgLjVFVvHZXHbxEQkRr
+72oArwIh5G9HSI4n6AWaPFutPnoYPlGwZ8oDC73Gg5/RhHT5cdbpg6FSgmdjw4aN
+aQ+bnjDUcPJMnWZVhs2oWupH8lEhkoTxOeL2x+PCEWDgjjVfnn9/4k7j1T7zmT7X
+nbIyBblDckt6tVrpQ31xR7XQEDvsYTBkY+kUnESUFky6GnjS9QUdvxWE+srVo0vv
+u8jlwCv0wRhJWVN57xBzYRho2UYB9aWH+cV0TcUp5Ic2mdJbMnRH7mk0VQEPS6Km
+k3IpECe3RgwVMeb/dst2Ppq9ZU8cNTA1LccNZNeDvJ042E5tg9VLtitkskIDqOfx
+bOZIiybV3raab63P4IfD15ExkE21ut3xjh3y5hevCi8FLP1d3e+yxLPQNIQNfYvz
+jSkCAwEAATANBgkqhkiG9w0BAQ0FAAOCAgEAY4ofAE0LS/nldp4iMttP5IQK9N9A
+N2g/TnEywFRkG9Ckrg+SgagK6baTG5AEDgDNnsu+oTbnWp6Sz4gnMX8sBysSzK1G
+RoujiaX6gJFrK6AbJkKXd+fQryfDMC299/oufmDhwx2IhxVqV26940n/aIv4nNTx
+prqiUwgvaX+5lAzwwcjBhbeDxyLW2TUFdU3KTu7G0TOda314gi+hEUroofavlSXE
+wc1ca7nAAnqWBRjUbqTZXuz/JeG+QDo7k9AzEiV5mJosin+SBWrhkC+W2OcJqOSu
+WdJ9mTBc7npXKz3IqtdqnWjDQ97ibzsiOxfUzTBmxi04OY3Uj6/p9x6fmw2/1zks
+zXrgVOWuXbpCnifqZ85NG8a2ILNu2sksRveK6IuA/Xn7y9EIyZE4tYVuZzKh7r8i
+kGRyTU6rQGGpkHyeCEhQn1UCRXUK1p5whD9SzdUB7UVsXuxS2cLZ/a1xsYooQRxn
+R9rXEBZPw4Yq0CBYgu16ctCQl/i3XM7v142ty4zUPRjFnhL5a9QdIV9Grf17Oxb8
+RW3gPm8x1UrbJcljCTdUzCbpgSBKnuZ2QqhTU5DnDPQAgR0dkOmHvBbByzmLTFVl
+lG8noEzbDBthYR/aWiiKW3wvgFXQFwGnctYQywZblE1MgTbxA+MRZF65fZ/4dVHS
+pWKwuwi5bVZ7Og4=
 -----END CERTIFICATE-----
 subject=CN = *.example.com
 issuer=CN = *.example.com
@@ -43,7 +43,7 @@ Peer signing digest: SHA256
 Peer signature type: RSA-PSS
 Server Temp Key: X25519, 253 bits
 ---
-SSL handshake has read 2160 bytes and written 441 bytes
+SSL handshake has read 2160 bytes and written 445 bytes
 Verification: OK
 ---
 New, TLSv1.2, Cipher is ECDHE-RSA-AES256-GCM-SHA384
@@ -55,47 +55,31 @@ No ALPN negotiated
 SSL-Session:
     Protocol  : TLSv1.2
     Cipher    : ECDHE-RSA-AES256-GCM-SHA384
-    Session-ID: 6B0C72430E8B027799702FE7F20E91DE26541F2CEC01460BBF7360B14ACED56C
+    Session-ID: C3457FD015C448E3DC01B36A9945A79F05CD890E7D87C5F1521F7A5764038D13
     Session-ID-ctx: 
-    Master-Key: E27B16EED948CAB4C780DE9312E8E40061D234AB9ABC19CC6E27D70316DD2D2D7A7092944D5AA9122401756E0C2810DC
+    Master-Key: E44BD03C41DE01D3D0223FEDC4A6C03EBC0D9F9C019DD38F9024728114423F9EAF29C60F7BF001428194D513A33466D4
     PSK identity: None
     PSK identity hint: None
     SRP username: None
     TLS session ticket lifetime hint: 300 (seconds)
     TLS session ticket:
-    0000 - 1c ca d7 0e cf 6c 16 9b-a0 ce 09 a7 0f 56 45 b7   .....l.......VE.
-    0010 - 93 20 e8 72 d2 ef 8d 40-52 21 b4 13 1e 4a 5b f9   . .r...@R!...J[.
-    0020 - 9c ee df 51 5b fb 30 d7-6c 1c 2e 42 47 a0 ca 80   ...Q[.0.l..BG...
-    0030 - d2 68 fc e9 a6 e1 de c4-34 20 f7 f6 3f 96 9c bb   .h......4 ..?...
-    0040 - c0 01 e5 6d cb 4e 23 d1-06 25 8c ab cc 09 95 05   ...m.N#..%......
-    0050 - f2 3d 63 a5 f2 29 b8 ff-6d 7b 03 8a 61 91 d8 6a   .=c..)..m{..a..j
-    0060 - bc 51 e3 39 07 2e 55 3c-12 f7 77 b9 a8 78 28 43   .Q.9..U<..w..x(C
-    0070 - de 13 f8 50 0d 33 88 71-d2 28 82 73 a7 09 aa a5   ...P.3.q.(.s....
-    0080 - c3 a7 e2 f4 73 c7 84 ad-a0 73 dc 99 26 6b 68 d5   ....s....s..&kh.
-    0090 - af 71 6f e9 18 19 3a 6c-7a e2 85 16 6d eb f0 ac   .qo...:lz...m...
-    00a0 - a9 07 fb 43 98 80 28 12-07 d4 c1 28 76 a4 02 a4   ...C..(....(v...
-    00b0 - 0d a0 55 33 d5 2c f8 da-63 b0 33 47 21 d9 c1 af   ..U3.,..c.3G!...
-    00c0 - 71 cb 05 8a b7 67 bc 75-e7 29 53 03 d0 75 c0 ff   q....g.u.)S..u..
-    00d0 - 16 94 cb 22 52 2b f7 33-dc 23 e1 1c b8 76 5f 59   ..."R+.3.#...v_Y
+    0000 - 6c 47 cf ca 9a 70 b9 f8-16 db 1f 77 03 d0 1b 52   lG...p.....w...R
+    0010 - 65 84 80 16 ce 4e 2f 9c-c2 02 19 15 64 6b 79 cb   e....N/.....dky.
+    0020 - a6 35 d4 66 a8 70 02 69-74 26 4e 3f 3f 9c 4a 42   .5.f.p.it&N??.JB
+    0030 - 08 4c 2c 82 82 5e 49 78-e4 e5 6c d4 a3 42 4d b3   .L,..^Ix..l..BM.
+    0040 - c1 00 ca e0 6d ad f1 5a-42 02 eb fc 73 a3 e8 5e   ....m..ZB...s..^
+    0050 - 8b 03 98 00 ab 8a 3a 5f-51 a9 8b 81 56 47 56 2c   ......:_Q...VGV,
+    0060 - 73 e6 c4 2f 03 95 c7 f3-6c be 2e 60 fa 93 3c 83   s../....l..`..<.
+    0070 - 59 56 81 8c 9d 45 e5 f5-2e e2 42 cf 68 28 d0 df   YV...E....B.h(..
+    0080 - ac db ec 05 ea 43 37 0c-0e 35 37 3c 76 76 7a 42   .....C7..57<vvzB
+    0090 - 2a 39 45 bd d7 8a f3 c1-e6 ee 7b 5f d1 d5 be cc   *9E.......{_....
+    00a0 - 3f 2f 2a 83 69 fe ff 32-23 81 02 1d 86 3f 69 11   ?/*.i..2#....?i.
+    00b0 - f7 d6 a9 e3 1d b4 59 51-e7 37 6a 38 91 fd ae 5c   ......YQ.7j8...\
+    00c0 - f7 d4 b6 37 f1 70 c1 bc-5a 78 2f cc 3e 2d 27 9e   ...7.p..Zx/.>-'.
+    00d0 - 6d ac c8 c8 7f b4 81 e4-8f b0 e1 41 fa ab 6b ca   m..........A..k.
 
-    Start Time: 1717767231
+    Start Time: 1718107076
     Timeout   : 7200 (sec)
     Verify return code: 0 (ok)
     Extended master secret: yes
 ---
-HTTP/1.1 400 Bad Request
-Date: Fri, 07 Jun 2024 13:33:52 GMT
-Server: Apache/2.4.59 (Fedora Linux) OpenSSL/3.1.1
-Content-Length: 226
-Connection: close
-Content-Type: text/html; charset=iso-8859-1
-
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<html><head>
-<title>400 Bad Request</title>
-</head><body>
-<h1>Bad Request</h1>
-<p>Your browser sent a request that this server could not understand.<br />
-</p>
-</body></html>
-closed

--- a/log/openssl-s_client/tls-13.example.com.stderr.log
+++ b/log/openssl-s_client/tls-13.example.com.stderr.log
@@ -1,2 +1,3 @@
 depth=0 CN = *.example.com
 verify return:1
+DONE

--- a/log/openssl-s_client/tls-13.example.com.stdout.log
+++ b/log/openssl-s_client/tls-13.example.com.stdout.log
@@ -4,36 +4,36 @@ Certificate chain
  0 s:CN = *.example.com
    i:CN = *.example.com
    a:PKEY: rsaEncryption, 4096 (bit); sigalg: RSA-SHA512
-   v:NotBefore: Jun  7 13:33:18 2024 GMT; NotAfter: Jul  7 13:33:18 2024 GMT
+   v:NotBefore: Jun 11 11:57:48 2024 GMT; NotAfter: Jul 11 11:57:48 2024 GMT
 ---
 Server certificate
 -----BEGIN CERTIFICATE-----
-MIIEtzCCAp8CFHxM+nJCmNcT68fcqsMkNBnNxp6JMA0GCSqGSIb3DQEBDQUAMBgx
-FjAUBgNVBAMMDSouZXhhbXBsZS5jb20wHhcNMjQwNjA3MTMzMzE4WhcNMjQwNzA3
-MTMzMzE4WjAYMRYwFAYDVQQDDA0qLmV4YW1wbGUuY29tMIICIjANBgkqhkiG9w0B
-AQEFAAOCAg8AMIICCgKCAgEA4f/+lEgymd3u+vHQc8EpT7xXzYRAnb0FqnlTAA9d
-vFEo6D1qhMRbOqecVvAPyNkfmOp2R0zGAZLuSl65b2ZlIMFj1P6YmV6JvWJe7MRL
-phoK2ZBsdEIrBwjlKzoWZaKeMO2txU256oGr1YJBvU97O9ScUssboD+tLVE4I37i
-QfoNrDALKTMZ4vRRug98ZxCYBp7eK1s+nizU+474jf+Ppr4fdiXn+AtOQAqOkN9k
-4XrWr+f/Uua3t2k3siRAvG3KaQFJisTPWPvitYZS0lR1lGx0BmLU5cTu+G+GDbdM
-rLPL7jdQeBusWt++mPCu8NgAdktRYXm1K34LLyQgkiv8kpb/Tw4CGZaTkBA/0Q+X
-w/IBET0uiG0VPYIDlgWmMEjAqn3EmaH4sxQoqoDfRfiSAqC4cMkozxvyP1XuqgUv
-etkVNLaHnREuoZ0X/mPsltvMLsU10+QG2EqPqtNhXjQRDMyFNrloj0T3VlNYIEKX
-xveyAggtG7Yk567eMeInweXQdWpP0ZEApAPHAxMY/FgllyrSnHXIIwT+JZspNS4y
-ezeP+tOFP1v1iXRJscYeHWCZcShYhb/SetHKUTN7VgIFFqgqTsleS98shHy3Ui7h
-j4RIZYjt+x3mAXUsSgVeJkdA9GRxhnCnhEb9LTbGsb+st9f8+BWIpBguWGQ1ECvu
-Aj0CAwEAATANBgkqhkiG9w0BAQ0FAAOCAgEAK6Pv8ESMcuxWAfFmZVyrOeCVGzV7
-ZSb3W9fD+7LHduTG/Irh0JLmsgKmauaBV+Io3UOrdQKUfeMrxdqCG0Y7lupVuv6S
-x20K40PmPwi0GeZHt0Im9FvCFvuo7YzaPHKx3clA1KEDcxUNlUK8O2rIplvWv05K
-d/2lyszo8l0kodcDNL8vzUQz2xXHKOfPOz/V5be2cS3KpMjeDfTEdGsZrohZu1Fk
-Mqx75N3vav9C6UwPDNKWxq9Tdfi85BsPYG/CZa1IUwzlA9CsUzs+q/QwqD5aL5DC
-v97cB2Ah5O9XPDVCWx6IeFJ10D/edF7qM1N4O2jw5eDng4xQ8JYINZgV8n0ffzej
-RqB+EPk1PKdcnDSG82oDbZA2ruQ9qEcRRk0JFLp6FT9F+BXPOpi9q0ljdOq4LTwC
-ZYtktwGRySiZavB2aVnS79+wQHry7Wlfzak/rx8hi8Nz3anH8VREPLeYJdkpi/eH
-L4DXkI9Yy7mxNUpf3zeE57u3tzn4QoTXfnv4Llq3fkPmPyEW7ISnf3UFcU1tBY8r
-4FLNboFOitj8TSmCD4kjAn80ryFFwY3jFlKYZ4PkU292jkhewuNRKQczjkv6XdAJ
-RxiER9oic90u6n7Xeu+k5yFOEE7v8bPAMuJZCHtja/bOPxWEl2ft6fy7a8pxzLAN
-qE0ZG816/MUuTww=
+MIIEtzCCAp8CFEyaGdxPpoNY4Rz62jUDfOK24yIgMA0GCSqGSIb3DQEBDQUAMBgx
+FjAUBgNVBAMMDSouZXhhbXBsZS5jb20wHhcNMjQwNjExMTE1NzQ4WhcNMjQwNzEx
+MTE1NzQ4WjAYMRYwFAYDVQQDDA0qLmV4YW1wbGUuY29tMIICIjANBgkqhkiG9w0B
+AQEFAAOCAg8AMIICCgKCAgEAwgt4Rb+wZinXrtB3wtv0GAVAXPm9Y+2YkwHdd0qH
+BWLREyuXagXhn5iIvOGhkFe5OaPruKr+VrICzNvR7WYuSOaY6nTwaKJLXko4oH2f
+Aleq0a8L07PcLh5kptCtRRN6dWl/IQwHxjVpDjXGK9KTyvBx1b8Am7jiRb6QU65Q
+L8pokv5uHW9HxysGNCR0B6Sk4hZo473oLQzrOP0ZaPnhGQ6a3FPmPEH1ZnJoGWXg
+1reIruZpOv/VI7VBBWXsRH0/KQQwdObzb+JG0aT5sAT7BIgLjVFVvHZXHbxEQkRr
+72oArwIh5G9HSI4n6AWaPFutPnoYPlGwZ8oDC73Gg5/RhHT5cdbpg6FSgmdjw4aN
+aQ+bnjDUcPJMnWZVhs2oWupH8lEhkoTxOeL2x+PCEWDgjjVfnn9/4k7j1T7zmT7X
+nbIyBblDckt6tVrpQ31xR7XQEDvsYTBkY+kUnESUFky6GnjS9QUdvxWE+srVo0vv
+u8jlwCv0wRhJWVN57xBzYRho2UYB9aWH+cV0TcUp5Ic2mdJbMnRH7mk0VQEPS6Km
+k3IpECe3RgwVMeb/dst2Ppq9ZU8cNTA1LccNZNeDvJ042E5tg9VLtitkskIDqOfx
+bOZIiybV3raab63P4IfD15ExkE21ut3xjh3y5hevCi8FLP1d3e+yxLPQNIQNfYvz
+jSkCAwEAATANBgkqhkiG9w0BAQ0FAAOCAgEAY4ofAE0LS/nldp4iMttP5IQK9N9A
+N2g/TnEywFRkG9Ckrg+SgagK6baTG5AEDgDNnsu+oTbnWp6Sz4gnMX8sBysSzK1G
+RoujiaX6gJFrK6AbJkKXd+fQryfDMC299/oufmDhwx2IhxVqV26940n/aIv4nNTx
+prqiUwgvaX+5lAzwwcjBhbeDxyLW2TUFdU3KTu7G0TOda314gi+hEUroofavlSXE
+wc1ca7nAAnqWBRjUbqTZXuz/JeG+QDo7k9AzEiV5mJosin+SBWrhkC+W2OcJqOSu
+WdJ9mTBc7npXKz3IqtdqnWjDQ97ibzsiOxfUzTBmxi04OY3Uj6/p9x6fmw2/1zks
+zXrgVOWuXbpCnifqZ85NG8a2ILNu2sksRveK6IuA/Xn7y9EIyZE4tYVuZzKh7r8i
+kGRyTU6rQGGpkHyeCEhQn1UCRXUK1p5whD9SzdUB7UVsXuxS2cLZ/a1xsYooQRxn
+R9rXEBZPw4Yq0CBYgu16ctCQl/i3XM7v142ty4zUPRjFnhL5a9QdIV9Grf17Oxb8
+RW3gPm8x1UrbJcljCTdUzCbpgSBKnuZ2QqhTU5DnDPQAgR0dkOmHvBbByzmLTFVl
+lG8noEzbDBthYR/aWiiKW3wvgFXQFwGnctYQywZblE1MgTbxA+MRZF65fZ/4dVHS
+pWKwuwi5bVZ7Og4=
 -----END CERTIFICATE-----
 subject=CN = *.example.com
 issuer=CN = *.example.com
@@ -43,7 +43,7 @@ Peer signing digest: SHA256
 Peer signature type: RSA-PSS
 Server Temp Key: X25519, 253 bits
 ---
-SSL handshake has read 2027 bytes and written 428 bytes
+SSL handshake has read 2027 bytes and written 432 bytes
 Verification: OK
 ---
 New, TLSv1.3, Cipher is TLS_AES_256_GCM_SHA384
@@ -55,93 +55,3 @@ No ALPN negotiated
 Early data was not sent
 Verify return code: 0 (ok)
 ---
-HTTP/1.1 400 Bad Request
-Date: Fri, 07 Jun 2024 13:33:52 GMT
-Server: Apache/2.4.59 (Fedora Linux) OpenSSL/3.1.1
-Content-Length: 226
-Connection: close
-Content-Type: text/html; charset=iso-8859-1
-
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<html><head>
-<title>400 Bad Request</title>
-</head><body>
-<h1>Bad Request</h1>
-<p>Your browser sent a request that this server could not understand.<br />
-</p>
-</body></html>
----
-Post-Handshake New Session Ticket arrived:
-SSL-Session:
-    Protocol  : TLSv1.3
-    Cipher    : TLS_AES_256_GCM_SHA384
-    Session-ID: 1CAD428910DF1F827254B5A31BF8907589D103C14F3BE38A2F8DECDD0569B9BE
-    Session-ID-ctx: 
-    Resumption PSK: 2D95FE3D2A8797CB448B43A46236D337BECE4B6EF32082EEB42DD473D304DDF413A9579545C3BFCCEE9502ECE424D6E7
-    PSK identity: None
-    PSK identity hint: None
-    SRP username: None
-    TLS session ticket lifetime hint: 300 (seconds)
-    TLS session ticket:
-    0000 - 1c ca d7 0e cf 6c 16 9b-a0 ce 09 a7 0f 56 45 b7   .....l.......VE.
-    0010 - 67 c4 59 6f 31 4a 4a e1-7d 5f e5 1d b6 b9 65 49   g.Yo1JJ.}_....eI
-    0020 - f6 98 bf 7a e4 9f 22 07-a6 6d fc b8 e7 1d 0a 28   ...z.."..m.....(
-    0030 - ea fc d5 ad c5 b3 4f 38-3f b1 ba 7f d9 59 f9 55   ......O8?....Y.U
-    0040 - 48 68 4f 9a e8 c0 68 2f-76 55 c9 e9 96 7b 62 82   HhO...h/vU...{b.
-    0050 - 2d ea 34 57 bc f8 8f 95-56 2d 99 03 06 bf ea f8   -.4W....V-......
-    0060 - 66 0b 8e 6c dc a4 5b 12-55 5e 7d 75 cf 3f 1a 0b   f..l..[.U^}u.?..
-    0070 - 02 8d c5 0a 31 63 c0 ec-a4 43 d9 92 84 0f 8b 6c   ....1c...C.....l
-    0080 - c3 e4 66 b8 73 6e 48 4a-27 cd 70 4b c1 29 26 5c   ..f.snHJ'.pK.)&\
-    0090 - 2e 44 d6 f0 9e 3c 27 8e-5b 77 1e f6 50 b4 8a 65   .D...<'.[w..P..e
-    00a0 - d9 20 ea 05 51 58 c2 42-88 36 2e c1 8d c0 70 2b   . ..QX.B.6....p+
-    00b0 - 92 3d f3 f0 6f fc 9a 1a-8f c3 19 d0 ef f3 dc 20   .=..o.......... 
-    00c0 - 1b 45 7e 70 73 ef 6c 09-60 3b 4b cd 4a 30 06 7c   .E~ps.l.`;K.J0.|
-    00d0 - bb 97 9d 8a 0a 7a 37 40-ab 7c cf 8d 78 3c 0d 00   .....z7@.|..x<..
-    00e0 - d6 e2 7b 36 76 cf 65 71-e8 f7 17 35 98 e1 ec 76   ..{6v.eq...5...v
-    00f0 - 7a b1 45 58 31 f5 2d de-2e 20 3c 78 3e 14 c8 dd   z.EX1.-.. <x>...
-
-    Start Time: 1717767232
-    Timeout   : 7200 (sec)
-    Verify return code: 0 (ok)
-    Extended master secret: no
-    Max Early Data: 0
----
-read R BLOCK
----
-Post-Handshake New Session Ticket arrived:
-SSL-Session:
-    Protocol  : TLSv1.3
-    Cipher    : TLS_AES_256_GCM_SHA384
-    Session-ID: 8099AE743AA044F66967AB2A82B41787FD851DDBF08110B28077B3A8B71E68EA
-    Session-ID-ctx: 
-    Resumption PSK: 19B04046EF2DB1B15BF1AFC28C91F0DB40F01D34EFE204F7E673708262F412B4201ED9C1BFD3FAB2309CA3738DC9339F
-    PSK identity: None
-    PSK identity hint: None
-    SRP username: None
-    TLS session ticket lifetime hint: 300 (seconds)
-    TLS session ticket:
-    0000 - 1c ca d7 0e cf 6c 16 9b-a0 ce 09 a7 0f 56 45 b7   .....l.......VE.
-    0010 - 59 c0 14 ea bb 90 2d 1a-6a be a0 d8 1a 39 c4 06   Y.....-.j....9..
-    0020 - 7e cd e7 e2 9e cb 97 8b-59 9a c3 50 74 df a1 60   ~.......Y..Pt..`
-    0030 - 0a 7b eb bf 3e c2 2d d5-0f ef df 40 96 d1 41 be   .{..>.-....@..A.
-    0040 - 98 70 8d a7 23 57 e0 c3-1d 16 ef 74 ec b8 44 47   .p..#W.....t..DG
-    0050 - ad 74 83 09 e6 3c f6 8d-27 30 fe 43 69 38 18 24   .t...<..'0.Ci8.$
-    0060 - 00 0c 2d 59 a4 ac 4f cf-ab 7a aa 08 54 aa bd ad   ..-Y..O..z..T...
-    0070 - 1c 77 5b f0 87 06 82 00-43 b4 79 50 cd bc 5a f1   .w[.....C.yP..Z.
-    0080 - d8 8d 0d 2d 2c 8e e2 f6-87 1c 9a 32 e2 7d a4 7a   ...-,......2.}.z
-    0090 - ca e0 b8 1d b0 ac 55 56-56 e3 43 fa 0c 83 f0 43   ......UVV.C....C
-    00a0 - e6 06 c3 ba e6 bf c3 50-6f 65 b7 2a 3c 1f f0 86   .......Poe.*<...
-    00b0 - f5 ac ff 43 d3 19 34 58-3d 7d 78 24 e7 6b a2 43   ...C..4X=}x$.k.C
-    00c0 - 63 5b 61 58 b7 73 e1 cb-b9 ea 96 d8 5a fb 33 f2   c[aX.s......Z.3.
-    00d0 - 34 fc 81 d9 5f 2c 02 48-b1 97 f3 65 9a 78 aa 32   4..._,.H...e.x.2
-    00e0 - 06 49 9f 50 ae 87 d4 1a-50 73 b9 85 43 f8 68 4b   .I.P....Ps..C.hK
-    00f0 - 3b c0 44 a1 41 6c 9f 38-b1 ae 67 7c 22 51 81 76   ;.D.Al.8..g|"Q.v
-
-    Start Time: 1717767232
-    Timeout   : 7200 (sec)
-    Verify return code: 0 (ok)
-    Extended master secret: no
-    Max Early Data: 0
----
-read R BLOCK
-closed

--- a/setup.sh
+++ b/setup.sh
@@ -17,6 +17,8 @@ INSTALLED_RPM_PKGS="
     httpd \
     mod_ssl
 "
+CRYPTO_POLICY="$(update-crypto-policies --show)"
+CRYPTO_POLICY_DIR="/usr/share/crypto-policies/${CRYPTO_POLICY}"
 TIMESTAMP_NOW="$(date "+%Y%m%d%H%M%S")"
 
 rm -rf "${TMP_DIR}"
@@ -77,6 +79,16 @@ if ! grep -E "tls-[0-9]+.${SSL_DOMAIN}" /etc/hosts; then
     # Append the testing domains.
     cat "${TMP_DIR}/hosts" | sudo tee -a /etc/hosts
     cat /etc/hosts
+fi
+
+# At the SECLEVEL 1, OpenSSL no longer considers the SHA1-MD5 digest and
+# TLS < 1.2. The signatures using SHA1 and MD5 are also forbidden at this level
+# as they have less than 80 security bits. Additionally, SSLv3, TLS 1.0,
+# TLS 1.1 and DTLS 1.0 are all disabled at this level.
+if ! grep 'SECLEVEL=0' "${CRYPTO_POLICY_DIR}/opensslcnf.txt"; then
+    # Backup the opensslcnf.txt file just in case.
+    sudo cp -p "${CRYPTO_POLICY_DIR}/opensslcnf.txt" "${CRYPTO_POLICY_DIR}/opensslcnf.txt.${TIMESTAMP_NOW}"
+    sudo sed -i -e 's/SECLEVEL=[1-9]/SECLEVEL=0/' "${CRYPTO_POLICY_DIR}/opensslcnf.txt"
 fi
 
 # Run HTTPD.


### PR DESCRIPTION
There were 2 issues causing the incorrect SSL connection.

The 1st issue was the `openssl s_client` was in the waiting status in the script. As a solution, redirected the command's stdin to `/dev/null`. The `openssl s_client` waited for input when it connected successfully. This also fixes the issue that you need to type enter a few times to exit the command.

The 2nd issue was that the `SECLEVEL=1` defined in the file below prevents a SSL client from connecting with SHA1-MD5 digest and TLS < 1.2.

/usr/share/crypto-policies/<secuirty_policy>/opensslcnf.txt

Updated the log files and documents by this change too.