### PR TITLE
Stop generating cert.conf from the template.

### DIFF
--- a/cert.conf
+++ b/cert.conf
@@ -7,4 +7,4 @@ distinguished_name = req_distinguished_name
 # specified in config file" without this setting.
 commonName = Common Name (hostname, IP, or your name)
 # Enable all the sub-domains of the domain.
-commonName_default = *.@DOMAIN@
+commonName_default = *.example.com

--- a/setup.sh
+++ b/setup.sh
@@ -77,9 +77,7 @@ command -v openssl
 "${OPENSSL_DIR}/bin/openssl" version
 
 "${OPENSSL_DIR}/bin/openssl" genrsa -out "${TMP_DIR}/test.key" 4096
-sed -e "s/@DOMAIN@/${SSL_DOMAIN}/g" "${ROOT_DIR}/assets/cert.conf.tmpl" \
-    > "${TMP_DIR}/cert.conf"
-"${OPENSSL_DIR}/bin/openssl" req -new -key "${TMP_DIR}/test.key" -config "${TMP_DIR}/cert.conf" \
+"${OPENSSL_DIR}/bin/openssl" req -new -key "${TMP_DIR}/test.key" -config "cert.conf" \
     -out "${TMP_DIR}/test.csr" -sha512 -batch
 "${OPENSSL_DIR}/bin/openssl" x509 -req -in "${TMP_DIR}/test.csr" -signkey "${TMP_DIR}/test.key" \
     -out "${TMP_DIR}/test.crt" -sha512


### PR DESCRIPTION
It's more convenient to share the reproducing steps to others.